### PR TITLE
How to invoke RestClient with OAuth2 in Scheduled Task

### DIFF
--- a/src/main/java/com/example/springsecurityrestclient/Application.java
+++ b/src/main/java/com/example/springsecurityrestclient/Application.java
@@ -2,8 +2,10 @@ package com.example.springsecurityrestclient;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class Application {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/springsecurityrestclient/ClientConfig.java
+++ b/src/main/java/com/example/springsecurityrestclient/ClientConfig.java
@@ -20,15 +20,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.ClientHttpRequestInitializer;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
 import org.springframework.security.oauth2.client.endpoint.OAuth2ClientCredentialsGrantRequest;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedClientManager;
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
 
@@ -91,24 +91,25 @@ public class ClientConfig {
 
         ClientHttpRequestInterceptor interceptor = new OAuth2ClientInterceptor(authorizedClientManager, clientRegistration);
         return restTemplateBuilder
-                .requestCustomizers()
-                .additionalInterceptors(interceptor)
-                .build();
+            .requestCustomizers()
+            .additionalInterceptors(interceptor)
+            .build();
     }
 
     @Bean
     OAuth2AuthorizedClientManager authorizedClientManager(
-            OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> responseClient,
-            ClientRegistrationRepository clientRegistrationRepository,
-            OAuth2AuthorizedClientRepository authorizedClientRepository) {
+        OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> responseClient,
+        ClientRegistrationRepository clientRegistrationRepository,
+        OAuth2AuthorizedClientService clientService) {
 
         OAuth2AuthorizedClientProvider authorizedClientProvider =
-                OAuth2AuthorizedClientProviderBuilder.builder()
-                        .clientCredentials(clientCredentials ->
-                                clientCredentials.accessTokenResponseClient(responseClient))
-                        .build();
+            OAuth2AuthorizedClientProviderBuilder.builder()
+                .clientCredentials(clientCredentials ->
+                    clientCredentials.accessTokenResponseClient(responseClient))
+                .build();
 
-        DefaultOAuth2AuthorizedClientManager clientManager = new DefaultOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientRepository);
+        AuthorizedClientServiceOAuth2AuthorizedClientManager clientManager =
+            new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, clientService);
         clientManager.setAuthorizedClientProvider(authorizedClientProvider);
         return clientManager;
     }

--- a/src/main/java/com/example/springsecurityrestclient/CronService.java
+++ b/src/main/java/com/example/springsecurityrestclient/CronService.java
@@ -1,0 +1,23 @@
+package com.example.springsecurityrestclient;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class CronService {
+
+  private static final String TARGET = "http://localhost:8081/target";
+
+  private RestClient restClientJwt;
+
+  @Scheduled(cron = "0 */1 * * * *")
+  public void performCronTask() {
+    log.info("cronJob called");
+    restClientJwt.get().uri(TARGET).retrieve().body(String.class);
+  }
+}


### PR DESCRIPTION
This pull request provides an example of an invocation of a RestClient with `Scheduling`. 
Executing RestClient with Scheduling necessitates minor configuration adjustments to enable OAuth integration in a non-web context. Otherwise it was throwing an Exception (see [Issue 1](https://github.com/mjeffrey/spring-security-oauth2-restclient-interceptor/issues/1)). Issue can be reproduced with commit 5b57721634e1697bdab4e9d2feeb07836a79028e.

Previous setup is still working with new configuration.

